### PR TITLE
fix : remove thumbprint data from keyvault certificates

### DIFF
--- a/src/spaceone/inventory/model/keyvault/data.py
+++ b/src/spaceone/inventory/model/keyvault/data.py
@@ -115,7 +115,6 @@ class CertificateItem(Model):
     _attributes = ModelType(CertificateAttributes, serialize_when_none=False)
     _id = StringType(serialize_when_none=False)
     _content_type = StringType(serialize_when_none=False)
-    _x509_thumbprint = StringType(serialize_when_none=False)
     _tags = ModelType(Tags, serialize_when_none=False)
     _vault_id = ModelType(VaultId, serialize_when_none=False)
 


### PR DESCRIPTION
### Category
- [ ] New feature
- [x] Bug fix
- [ ] Improvement
- [ ] Refactor
- [ ] etc

### Description
```
return import_loop(cls, mutable, raw_data, import_converter, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/schematics/transforms.py", line 174, in import_loop
    raise DataError(errors, data)
schematics.exceptions.DataError: {"certificates": {"0": {"_x509_thumbprint": ["Invalid UTF-8 data."]}}}

[ERROR: ResourceInfo]: {"certificates": {"0": {"_x509_thumbprint": ["Invalid UTF-8 data."]}}} 
```

### Known issue
